### PR TITLE
Deploy action version output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
       - name: Generate app with ucc-gen
         uses: splunk/addonfactory-ucc-generator-action@v3.0.0
         with:
-          version: ${{ steps.version.VERSION_WITH_HASH }}
+          version: ${{ steps.version.outputs.VERSION_WITH_HASH }}
 
       - name: Generate Package tarball
         shell: bash


### PR DESCRIPTION
Fixes "Could not find the proper version from git tags" error by correcting how the version output is referenced.

The previous syntax `steps.version.VERSION_WITH_HASH` could evaluate to empty, causing the `splunk/addonfactory-ucc-generator-action` to fall back to git tag resolution and fail. Changing it to `steps.version.outputs.VERSION_WITH_HASH` ensures the version is always correctly passed.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b95c773-78e9-414a-a1b8-597a00b95f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b95c773-78e9-414a-a1b8-597a00b95f1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

