### PR TITLE
Bump forked appinspect-cli-action to v2.13.1-py312

### DIFF
--- a/.github/workflows/appinspect-cli.yml
+++ b/.github/workflows/appinspect-cli.yml
@@ -39,7 +39,12 @@ jobs:
           # Forked action: builds on python:3.12 so the well-formed Python
           # check parses modern vendored libs. Upstream pins a python:3.7.10
           # image that SyntaxErrors on them. See livehybrid/appinspect-cli-action.
-          uses: livehybrid/appinspect-cli-action@v2.13.0-py312
+          #
+          # 2.13.1 fixes a regex that raised re.error on 3.11+, which made the
+          # whole .appinspect.expect.yaml waiver mechanism inert on this fork:
+          # any repo with a legitimate documented waiver failed anyway, with a
+          # traceback that said nothing about the app.
+          uses: livehybrid/appinspect-cli-action@v2.13.1-py312
           with:
             app_path: dist/
             included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
Repoints the shared AppInspect CLI workflow at `v2.13.1-py312`.

## Why

`v2.13.0-py312` carries a bug that makes the **expected-failures mechanism inert for every consumer of this workflow**. `compare_checks.py` compiled:

```python
re.compile(r"((?i)(ADDON|APPCERT)-[0-9]+)")
```

A global inline flag that is not at the start of the pattern was deprecated in Python 3.6 and is a **hard error** in 3.11:

```
re.error: global flags not at the start of the expression at position 1
```

This fork builds on `python:3.12` (so the well-formed-Python check can parse modern vendored libraries), so the pattern raises instead of warning. Upstream's `python:3.7.10` image only warns, which is why it went unnoticed when the fork was cut.

The effect: the moment AppInspect reports a real failure, `compare_checks.py` crashes with a traceback before it can read `.appinspect.expect.yaml`. A repo with a legitimate, ticket-referenced waiver fails CI anyway, and the log says nothing about the app.

It stayed invisible because `entrypoint.sh` only invokes the failure comparison when appinspect exits non-zero, and until recently few repos had anything to waive.

## Why now

The AppInspect 4.3.0 mako finding puts a waiver into **13 estate repos** via Dependabot. Without this bump they all go red on an error that has nothing to do with their apps.

## Verification

Ran on `python:3.12-slim`, matching the action image:

| Input | v2.13.0 | v2.13.1 |
|---|---|---|
| the pattern itself | `re.error` | compiles |
| `ADDON-0005: x` | crash | accepted |
| `appcert-12 y` | crash | accepted (case-insensitivity preserved) |
| `just words` | crash | flagged, as intended |
| entry with no `comment` key | `TypeError` | flagged |

Upstream: livehybrid/appinspect-cli-action#1. Worth reporting to `splunk/appinspect-cli-action` too — it is a latent 3.11+ incompatibility in their tree regardless of this fork.