### PR TITLE
Check out the repo in the AppInspect API job

### DIFF
--- a/.github/workflows/appinspect-api.yml
+++ b/.github/workflows/appinspect-api.yml
@@ -13,6 +13,15 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      # Must come BEFORE download-artifact, so the artifact is not disturbed.
+      #
+      # Without a checkout the runner workspace holds only dist/, so the repo's
+      # .appinspect_api.expect.yaml is never present and the action fails with
+      # "File .appinspect_api.expect.yaml not found" the moment the API reports
+      # any failure. That made the API-side waiver mechanism impossible for every
+      # consumer of this workflow: a repo could waive a finding for the CLI legs
+      # and still have this job go red on a file it had actually committed.
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:
           name: dist


### PR DESCRIPTION
`quality-appinspect-api` never checks out the repository. It only downloads the `dist` artifact, so the runner workspace contains `dist/` and nothing else.

Consequence: **`.appinspect_api.expect.yaml` can never be found**, whatever the consuming repo commits. The moment the API reports a real failure, the job dies with:

```
ERROR: File `.appinspect_api.expect.yaml` not found, please create `.appinspect_api.expect.yaml` file with exceptions
```

The message is misleading. On `splunk-sok-console` the file was committed and present on `main`; it was simply never checked out.

## Why it went unnoticed

Same shape as the `compare_checks.py` regex bug fixed in #25: the API action only looks for the expect file **after** it detects a failure, and until recently no repo had an API-side failure to waive. SOK is the first, via `check_for_python_udp_network_communications` coming from the vendored botocore stack.

Until now the estate-wide symptom was masked by stale Splunkbase credentials, which made this job fail earlier, at authentication.

## The fix

Add `actions/checkout@v6` as the first step, **before** `download-artifact`, so the artifact is not disturbed.

## Note on the two expect files

The CLI and API legs read **different files**, which is easy to miss:

| Leg | File |
|---|---|
| `appinspect-cli.yml` | `.appinspect.expect.yaml` |
| `appinspect-api.yml` | `.appinspect_api.expect.yaml` |

So a repo with an API-side finding needs both, with the same content.